### PR TITLE
Fix typo in protocol-extensions documentation

### DIFF
--- a/docs/dev/protocol-extensions.md
+++ b/docs/dev/protocol-extensions.md
@@ -142,7 +142,7 @@ This will reduce contention over hot keys and thus increase LWT performance.
 The feature is identified by the `SCYLLA_LWT_ADD_METADATA_MARK` key that is
 meant to be sent in the SUPPORTED message along with the following additional
 parameters:
-  - `SCYLLA_LWT_OPTIMIZATION_META_BIT_MASK` is a 32-bit unsigned integer that represents
+  - `LWT_OPTIMIZATION_META_BIT_MASK` is a 32-bit unsigned integer that represents
     the bit mask that should be used by the client to test against when checking
     prepared statement metadata flags to see if the current query is conditional
     or not.


### PR DESCRIPTION
https://github.com/scylladb/scylladb/blob/d3c6e72c6934cb7b8f16231ea2fa7075d855202f/transport/cql_protocol_extension.cc#L34